### PR TITLE
"Edge://newtab" exclusion

### DIFF
--- a/extension/dist/background.js
+++ b/extension/dist/background.js
@@ -5,6 +5,7 @@ let keepAlive;
 const builtInURLs = [
     "https://google.com/",
     "chrome://",
+    "Edge://newtab",
     "chrome-extension://egmgebeelgaakhaoodlmnimbfemfgdah",
     "https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values",
     "https://github.com/Tyson3101/",

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,6 +16,7 @@ let keepAlive: ReturnType<typeof setInterval>;
 const builtInURLs = [
   "https://google.com/",
   "chrome://",
+  "Edge://newtab",
   "chrome-extension://egmgebeelgaakhaoodlmnimbfemfgdah",
   "https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values",
   "https://github.com/Tyson3101/",


### PR DESCRIPTION
Stops user-made new tabs on Microsoft Edge from automatically closing w/o interfering with website redirects